### PR TITLE
Don't register new objects every time the client reconnects to cloud

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,11 +29,24 @@ function myModule(opts,app) {
   opts.Locations = opts.Locations || new Array(defaultConfig());
   self.save();
 
+  this.devices = {};
+
   app.on('client::up',function(){
 
     // The client is now connected to the cloud
     opts.Locations.forEach(function (location) {
-         self.emit('register', new Device(location, app)); 
+      // prevent creating multiple objects each time the client connects to the cloud
+      var device = self.devices[location];
+      if (device == null) {
+        device = new Device(location, app);
+        self.devices[location] = device;
+        self.emit('register', device);
+
+        // wait 10secs to ensure that device is already registered before sending data
+        setTimeout(function() {
+          device.start();
+        }, 10000);
+      }
     });
  
   });

--- a/lib/device.js
+++ b/lib/device.js
@@ -32,6 +32,7 @@ datastatus = false;
 function Device(location, app) {
 
   var self = this;
+  this.app = app;
 
   // This device will emit data
   this.readable = true;
@@ -41,13 +42,19 @@ function Device(location, app) {
   this.G = "timeoofday"+location.name; // G is a string a represents the channel
   this.V = 0; // 0 is Ninja Blocks' device list
   this.D = 244; // 2000 is a generic Ninja Blocks sandbox device
-  this.name = location.name + " Time of Day "
-  this.currentMode = ''
-  setdayTimes(location); 
- 
+  this.name = location.name + " Time of Day ";
+  this.currentMode = '';
+  this.location = location;
+}
+
+Device.prototype.start = function() {
+
+  var self = this;
+  setdayTimes(this.location);
+
   function updateNinja(state)
   {
-    app.log.info(location.name + ': updating state to: ' + state)
+    self.app.log.info(self.location.name + ': updating state to: ' + state)
     self.emit('data',  state );
     self.currentMode = state;
   }
@@ -59,26 +66,17 @@ function Device(location, app) {
 
   
   function setdayTimes()
- {
-
-     phases = [];
-     
-     self.phases = phases;
-      
-     buildLoc(location);
-      
-     processTimes();
-
-    // wait 10secs to ensure that device is already registered before sending data
-    setTimeout(function() {
-      updateNinja(self.phases.State);
-    }, 10000);
- }
+  {
+    self.phases = [];
+    buildLoc(self.location);
+    processTimes();
+    updateNinja(self.phases.State);
+  }
  
-function buildLoc(loc)
-{
+  function buildLoc(loc)
+  {
       
-      phases = self.phases
+      var phases = self.phases
       
       phases.name = loc.name;
       phases.lat =  loc.latitude;
@@ -105,7 +103,7 @@ function buildLoc(loc)
                       display : time.display,
                       ms : 0};
             phases.push(Obj);
-                                  
+
         }
         else { 
              var timeObj = { name : time.name,
@@ -116,11 +114,11 @@ function buildLoc(loc)
         
       });
       
-}     
+  }
 
-function processTimes()     
-{
-       phases = self.phases;
+  function processTimes()
+  {
+       var phases = self.phases;
        var times = SunCalc.getTimes(new Date(), phases.lat, phases.lng);
        var nextDayTimes = SunCalc.getTimes(Date.tomorrow().addMinutes(5), phases.lat, phases.lng);
        var now = new Date();
@@ -135,10 +133,10 @@ function processTimes()
          }
          lc.alertTime = (lc.time - now.getTime()) ;  // ms to altert 
          if (lc.alertTime > 0) {
-            app.log.info(location.name +  ': setting up ' + lc.display + ' at ' + new Date(lc.time))
+            self.app.log.info(self.location.name +  ': setting up ' + lc.display + ' at ' + new Date(lc.time))
             setTimeout(updateNinja, lc.alertTime , lc.display)
          } else {
-            app.log.debug(location.name +  ': not setting up ' + lc.display + ' as ' + new Date(lc.time) + ' is in the past')
+            self.app.log.debug(self.location.name +  ': not setting up ' + lc.display + ' as ' + new Date(lc.time) + ' is in the past')
          }
        });
        
@@ -160,12 +158,12 @@ function processTimes()
        }); 
      
      
-       n = new Date();
-       tomorrow = Date.tomorrow().addMinutes(5);
-       app.log.info(location.name + ': scheduling recalc for: ' + tomorrow)
+       var n = new Date();
+       var tomorrow = Date.tomorrow().addMinutes(5);
+       self.app.log.info(self.location.name + ': scheduling recalc for: ' + tomorrow)
        setTimeout(setdayTimes, n.getSecondsBetween(tomorrow) * 1000);         
             
                 
-}
+  }
 
 }


### PR DESCRIPTION
Seems that if the client disconnects from cloud when reconnecting will send again the `client::up` event, creating more objects and scheduling more events, got up to 14 `scheduling recalc` messages in the log at the same time
Is that right @chrisn-au?
